### PR TITLE
framework/media: skip onplay cb when already closed

### DIFF
--- a/client/media_uv_graph.c
+++ b/client/media_uv_graph.c
@@ -647,7 +647,7 @@ static void media_uv_player_suggest_cb(int suggest, void* cookie)
 
     if (!player) {
         MEDIA_INFO("suggest:%d canceled\n", suggest);
-        goto out;
+        return;
     }
 
     MEDIA_INFO("%s:%p suggest:%d\n", player->name, player, suggest);
@@ -685,7 +685,6 @@ static void media_uv_player_suggest_cb(int suggest, void* cookie)
         break;
     }
 
-out:
     if (priv->on_play) {
         if (!suggest_active) /* Notify user if focus request failed. */
             priv->on_play(priv->on_play_cookie, -EPERM);
@@ -1025,7 +1024,7 @@ static void media_uv_recorder_suggest_cb(int suggest, void* cookie)
 
     if (!recorder) {
         MEDIA_INFO("suggest:%d canceled\n", suggest);
-        goto out;
+        return;
     }
 
     MEDIA_INFO("%s:%p suggest:%d\n", recorder->name, recorder, suggest);
@@ -1052,7 +1051,6 @@ static void media_uv_recorder_suggest_cb(int suggest, void* cookie)
         break;
     }
 
-out:
     if (priv->on_play) {
         if (!suggest_active) /* Notify user if focus request failed. */
             priv->on_play(priv->on_play_cookie, -EPERM);


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/open-vela/docs/blob/dev/CONTRIBUTING.md).*

## Summary

*Update this section with information on why change is necessary,
 what it exactly does and how, if new feature shows up, provide
 references (dependencies, similar problems and solutions), etc.*

## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*

